### PR TITLE
better format message when no conditional is satisfied on reporting status

### DIFF
--- a/services/services.go
+++ b/services/services.go
@@ -66,7 +66,7 @@ func reportStatus(service *ecs.Service, resp chan<- string) {
 	} else if status == "STOPPED" {
 		resp <- stoppedStatus.Sprintln(message)
 	} else {
-		resp <- message
+		resp <- activeNotRunningStatus.Sprintln(message)
 	}
 }
 


### PR DESCRIPTION
The status reported when no condition is satisfied on reportStatus function has no format and no new line character at end of the line. 
This PR uses the `activeNotRunningStatus` color object o apply a format and color to the text.